### PR TITLE
remove zero padding from date format

### DIFF
--- a/calendar.jsp
+++ b/calendar.jsp
@@ -50,7 +50,7 @@ function drawCalendar(dateData){
 
   var day = d3.timeFormat("%w"),
       week = d3.timeFormat("%U"),
-      format = d3.timeFormat("%m/%d/%Y"),
+      format = d3.timeFormat("%-m/%-d/%Y"),
       titleFormat = d3.utcFormat("%a, %d-%b");
       monthName = d3.timeFormat("%B"),
       months= d3.timeMonth.range(d3.timeMonth.floor(minDate), maxDate);


### PR DESCRIPTION
mismatch between json dates and formatted date in code. Oct-Dec worked because the months are two digits